### PR TITLE
Support for inlined type annotations for inherited attributes

### DIFF
--- a/lib/abstractDeps.ml
+++ b/lib/abstractDeps.ml
@@ -95,6 +95,7 @@ let simp_ast: TypeChecker.context -> ast -> (semantic_constraint Utils.StringMap
     ) (acc_dep_map, [], acc_ctx)  rhss in
     let dep_map = Utils.StringMap.merge Lib.union_keys dep_map Utils.StringMap.empty in
     dep_map, ProdRule (nt, ias, List.rev rhss, p) :: acc_elements, ctx 
+  | InlinedTypeProdRule _ -> assert false
   | TypeAnnotation (nt, ty, scs, p) -> 
     let scs = List.map (fun sc -> match sc with 
     | DerivedField (nt, expr, p) -> DerivedField (nt, calculate_casts expr, p)

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -129,6 +129,7 @@ type element =
 (* NT LHS * inherited attributes * RHSs * position *)
 | ProdRule of string * string list * prod_rule_rhs list * Lexing.position
 | TypeAnnotation of string * il_type * semantic_constraint list * Lexing.position
+| InlinedTypeProdRule of string * (string * il_type) list * prod_rule_rhs list * Lexing.position
 
 (* This is the type of the grammar terms *)
 type ast = element list
@@ -475,6 +476,14 @@ let pp_print_element: Format.formatter -> element ->  unit
     (Lib.pp_print_list Format.pp_print_string ", ") ias
     (Lib.pp_print_list pp_print_prod_rule_rhs " | ") rhss
 
+| InlinedTypeProdRule (nt, ias, rhss, _) -> 
+  Format.fprintf ppf "%a(%a) ::= %a;"
+    pp_print_nt_with_dots [nt, None]
+    (Lib.pp_print_list (fun ppf (ia_nt, ia_ty) -> 
+      Format.fprintf ppf "%s:: %a" ia_nt pp_print_ty ia_ty
+    ) ", ") ias
+    (Lib.pp_print_list pp_print_prod_rule_rhs " | ") rhss
+
 | TypeAnnotation (nt, ty, [], _) -> 
   Format.fprintf ppf "%a :: %a;"
     pp_print_nt_with_dots [nt, None] 
@@ -581,6 +590,7 @@ let ast_constrains_nt: ast -> string -> bool
   List.exists (fun element -> match element with 
     | TypeAnnotation (nt2, _, _ :: _, _) when nt = nt2 -> true 
     | TypeAnnotation _ -> false
+    | InlinedTypeProdRule _ -> assert false
     | ProdRule (_, _, rhss, _) -> List.exists (fun rhs -> match rhs with 
       | Rhs (_, scs, _, _) -> List.exists (sc_constrains_nt nt) scs
       | StubbedRhs _ -> false
@@ -612,6 +622,7 @@ let rec prepend_nt_to_dot_exprs: string -> expr -> expr
   | SynthAttr _ -> assert false
 
 let scs_of_element = function 
+| InlinedTypeProdRule _ -> assert false
 | ProdRule (_, _, rhss, _) -> 
   List.concat_map (function 
   | StubbedRhs _ -> [] 
@@ -621,6 +632,7 @@ let scs_of_element = function
 
 let rec nts_of_ast ast = match ast with 
 | [] -> Utils.StringSet.empty  
+| InlinedTypeProdRule _ :: _ -> assert false
 | ProdRule (nt, _, rhss, _) :: tl -> 
   let nts = nt :: (List.concat_map nts_of_rhs rhss) in 
   let nts = Utils.StringSet.of_list nts in 
@@ -631,6 +643,7 @@ let rec nts_of_ast ast = match ast with
 
 let find_element ast nt = 
   List.find (fun element -> match element with 
+  | InlinedTypeProdRule _ -> assert false
   | TypeAnnotation (nt', _, _, _) 
   | ProdRule (nt', _, _, _) -> String.equal nt nt'
   ) ast 

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -129,6 +129,10 @@ type element =
 (* NT LHS * inherited attributes * RHSs * position *)
 | ProdRule of string * string list * prod_rule_rhs list * Lexing.position
 | TypeAnnotation of string * il_type * semantic_constraint list * Lexing.position
+(* A production rule with inherited attributes that have type annotations inlined. *)
+(* The definition of the variable is local to the rule. *)
+(* This is merely an artifact from parsing, and is meant to be syntax sugar that wil
+ be translated to the appropriate regular ProdRule and TypeAnnotation after parsing. *)
 | InlinedTypeProdRule of string * (string * il_type) list * prod_rule_rhs list * Lexing.position
 
 (* This is the type of the grammar terms *)

--- a/lib/ast.mli
+++ b/lib/ast.mli
@@ -116,6 +116,7 @@ type element =
 (* NT LHS * inherited attributes * RHSs * position *)
 | ProdRule of string * string list * prod_rule_rhs list * Lexing.position
 | TypeAnnotation of string * il_type * semantic_constraint list * Lexing.position
+| InlinedTypeProdRule of string * (string * il_type) list * prod_rule_rhs list * Lexing.position
 
 type ast = element list
 

--- a/lib/attributeChecker.ml
+++ b/lib/attributeChecker.ml
@@ -10,6 +10,7 @@ let check_element attribute_ctx ctx element = match element with
     let msg = "Synthesized attribute definitions are not allowed in type annotations" in 
     Utils.error msg p
   else element
+| A.InlinedTypeProdRule _ -> assert false
 | A.ProdRule (nt, _, rhss, p) -> 
   (* Check all inherited attribute "calls" are type-correct and arity-correct 
      (also covering the "default" case where nothing is passed *)
@@ -75,6 +76,7 @@ let check_attributes ctx ast =
   (* Map from nonterminals to inferred attribute arg types *)
   let attribute_ctx = List.fold_left (fun acc element -> match element with 
   | A.TypeAnnotation _ -> acc 
+  | A.InlinedTypeProdRule _ -> assert false
   | A.ProdRule (nt, ias, _, _) -> 
     let tys = List.map (fun ia -> 
       let ia = "%_" ^ ia in 

--- a/lib/checkSolverAst.ml
+++ b/lib/checkSolverAst.ml
@@ -53,7 +53,7 @@ let handle_scs ast solver_ast constructor element scs =
   let scs = List.map (fun sc -> match sc with 
   | A.SmtConstraint (expr, p) -> 
     if is_sc_applicable expr solver_ast || (* type annotation constraints are always applicable *)
-       match element with | A.TypeAnnotation _ -> true | A.ProdRule _ -> false
+       match element with | A.TypeAnnotation _ -> true | A.InlinedTypeProdRule _ -> assert false | A.ProdRule _ -> false
     then (
       (if !Flags.debug then Format.fprintf Format.std_formatter "Constraint %a is applicable in %a"
         A.pp_print_expr expr
@@ -102,6 +102,7 @@ let rec check_syntax_semantics: Ast.ast -> SolverAst.solver_ast -> (unit, string
     let element = List.find_opt (fun element -> match element with
     | A.TypeAnnotation (nt, _, _, _) -> 
       Utils.str_eq_ci (Utils.extract_base_name constructor) nt 
+    | A.InlinedTypeProdRule _ -> assert false
     | A.ProdRule (nt, _, _, _) -> 
       Utils.str_eq_ci (Utils.extract_base_name constructor) nt 
     ) ast in (
@@ -109,6 +110,7 @@ let rec check_syntax_semantics: Ast.ast -> SolverAst.solver_ast -> (unit, string
     | None -> Error ("Dangling constructor identifier " ^ (Utils.extract_base_name constructor))
     | Some (TypeAnnotation (_, _, scs, _) as element) -> 
       handle_scs ast solver_ast constructor element scs
+    | Some (A.InlinedTypeProdRule _) -> assert false
     | Some (A.ProdRule (_, _, rhss, _) as element) ->
       (* Find the matching production rule from ast, if one exists *)
       let rhs = List.find_opt (fun rhs -> match rhs with 

--- a/lib/clpTranslator.ml
+++ b/lib/clpTranslator.ml
@@ -86,6 +86,7 @@ let rec create_field_extractors: A.ast -> string list -> clp_rule list
 | nt1 :: nt2 :: [] -> 
   let extractor = nt1 ^ "_" ^ nt2 ^ "s" in 
   let nt1_rhss = List.find_map (function 
+  | A.InlinedTypeProdRule _ -> assert false
   | A.ProdRule (nt, _, rhss, _) -> if nt1 = nt then Some rhss else None
   | TypeAnnotation _ -> None
   ) ast |> Option.get in
@@ -112,6 +113,7 @@ let rec create_field_extractors: A.ast -> string list -> clp_rule list
   let nt1_extractor = String.concat "_" (nt1 :: nt2 :: rest) ^ "s" in 
   let nt2_extractor = String.concat "_" (nt2 :: rest) ^ "s" in 
   let nt1_rhss = List.find_map (function 
+  | A.InlinedTypeProdRule _ -> assert false
   | A.ProdRule (nt, _, rhss, _) -> if nt1 = nt then Some rhss else None
   | TypeAnnotation _ -> None
   ) ast |> Option.get in
@@ -170,6 +172,7 @@ let extract_str input =
 
 let clp_program_of_ast: Ast.ast -> clp_program 
 = fun ast -> List.fold_left (fun acc element -> match element with 
+| A.InlinedTypeProdRule _ -> assert false
 | A.ProdRule (nt, _, rhss, _) -> 
   (* Create a CLP rule for each prod rule RHS *)
   let rules = List.mapi (fun i rhs -> match rhs with 

--- a/lib/computeDeps.ml
+++ b/lib/computeDeps.ml
@@ -101,6 +101,7 @@ let rec compute_dep: A.semantic_constraint Utils.StringMap.t -> SA.solver_ast ->
          *)
       let element' = List.find (fun element -> match element with 
       | A.TypeAnnotation _ -> false 
+      | A.InlinedTypeProdRule (_, _, _, _) -> assert false
       | A.ProdRule (_, _, rhss, _) ->
         List.exists (fun rhs -> match rhs with 
         | A.StubbedRhs _ -> false 
@@ -142,6 +143,7 @@ and evaluate: ?dep_map:A.semantic_constraint Utils.StringMap.t -> bool -> SA.sol
 | NTExpr (_, (id, idx0) :: rest, p) ->
   let child_index, child_element = match element with 
   | A.TypeAnnotation _ -> 0, element
+  | A.InlinedTypeProdRule _ -> assert false
   | A.ProdRule (_, _, rhss, _) ->
     (* Find child_index within the rule, not across all rules *) 
       let ci = List.find_map (fun rhs -> match rhs with 
@@ -157,6 +159,7 @@ and evaluate: ?dep_map:A.semantic_constraint Utils.StringMap.t -> bool -> SA.sol
       ) rhss in 
       Option.get ci, 
       List.find (fun element -> match element with 
+      | A.InlinedTypeProdRule _ -> assert false
       | A.TypeAnnotation (id2, _, _, _)
       | A.ProdRule (id2, _, _, _) -> Utils.str_eq_ci id id2
       ) ast 
@@ -483,6 +486,7 @@ and compute_deps: A.semantic_constraint Utils.StringMap.t -> A.ast -> SA.solver_
   List.map (fun subterm -> match subterm with 
   | SA.Node (_hd, [VarLeaf var]) -> 
     let element = List.find_opt (fun element -> match element with 
+    | A.InlinedTypeProdRule _ -> assert false
     | A.TypeAnnotation (nt, _, _, _)  
     | ProdRule (nt, _, _, _) -> 
       Utils.str_eq_ci nt (Utils.extract_base_name constructor)

--- a/lib/desugarAttributes.ml
+++ b/lib/desugarAttributes.ml
@@ -76,6 +76,7 @@ let gen_constraints_from_ge ast ge = match ge with
   List.mapi (fun i attr -> 
     let element = A.find_element ast nt in 
     match element with 
+    | A.InlinedTypeProdRule (_, _, _, _)  -> assert false
     | A.ProdRule (_, attr_params, _, _) -> 
       let attr_param = List.nth attr_params i in
       (*!!! TODO: If at a stage of the pipeline where `idx` is still None (and we haven't updated it here), 
@@ -89,6 +90,7 @@ let gen_constraints_from_ge ast ge = match ge with
 
 let desugar_attributes ctx ast = 
   let ast = List.map (fun element -> match element with 
+  | A.InlinedTypeProdRule _  -> assert false
   | A.ProdRule (nt, ias, rhss, p) -> 
     let rhss = List.map (fun rhs -> match rhs with 
     | A.StubbedRhs _ -> rhs

--- a/lib/desugarLocalVars.ml
+++ b/lib/desugarLocalVars.ml
@@ -1,0 +1,69 @@
+(* Desugar local variables by generating new nonterminals for inherited
+attributes *)
+
+module A = Ast
+
+(* For production rules with inlined type annotations for its inherited
+attributes, create a new type annotation for each inherited attributes,
+and desugar by adding the non-terminal as part of the name, then
+converting the InlinedTypeProdRule to a regular ProdRule. *)
+let desugar_local_vars ast =
+  List.concat_map (fun element -> match element with
+  | A.InlinedTypeProdRule (nt, typed_params, rhss, p) ->
+    let new_type_annotations = List.map (fun (ia, ty) ->
+      A.TypeAnnotation ("%_" ^ nt ^ "_" ^ ia, ty, [], p)
+    ) typed_params in
+    let rec desugar_expr expr = match expr with
+      | A.InhAttr (attr, p) -> (match List.find_opt (fun (ia, _) -> ia = attr) typed_params with
+        | Some _ -> A.InhAttr (nt ^ "_" ^ attr, p)
+        | None -> expr
+        )
+      | A.BinOp (e1, op, e2, p) ->
+        let e1 = desugar_expr e1 in
+        let e2 = desugar_expr e2 in
+        A.BinOp (e1, op, e2, p)
+      | A.CompOp (e1, op, e2, p) ->
+        let e1 = desugar_expr e1 in
+        let e2 = desugar_expr e2 in
+        A.CompOp (e1, op, e2, p)
+      | A.UnOp (op, e, p) ->
+        let e = desugar_expr e in
+        A.UnOp (op, e, p)
+      | A.BuiltInFunc (func, exprs, p) ->
+        let exprs = List.map desugar_expr exprs in
+        A.BuiltInFunc (func, exprs, p)
+      | A.Singleton (e, p) ->
+        let e = desugar_expr e in
+        A.Singleton (e, p)
+      | A.BVCast (len, e, p) ->
+        let e = desugar_expr e in
+        A.BVCast (len, e, p)
+      | A.SynthAttr _
+      | A.EmptySet _
+      | A.Match _
+      | A.NTExpr _
+      | A.BVConst _
+      | A.BLConst _
+      | A.BConst _
+      | A.IntConst _
+      | A.PhConst _
+      | A.StrConst _ -> expr in
+    let new_rhss = List.map (fun rhs -> match rhs with
+      | A.StubbedRhs _ -> assert false
+      | A.Rhs (ges, scs, prob, p) ->
+        let new_ges = List.map (fun ge -> match ge with
+          | A.StubbedNonterminal _ -> ge
+          | A.Nonterminal (nt1, idx, ias, p) ->
+            let new_ias = List.map (fun ia -> desugar_expr ia) ias in
+            A.Nonterminal (nt1, idx, new_ias, p)
+        ) ges in
+    let new_scs = List.map (fun sc -> match sc with
+      | A.SmtConstraint (e, p) -> A.SmtConstraint ((desugar_expr e), p)
+      | A.AttrDef _ -> sc
+      | DerivedField _ -> sc) scs in
+      A.Rhs (new_ges, new_scs, prob, p)
+    ) rhss in
+    let ias = List.map (fun (ia, _) -> nt ^ "_" ^ ia) typed_params in
+     [A.ProdRule (nt, ias, new_rhss, p)] @ new_type_annotations
+  | _ -> [element]
+  ) ast

--- a/lib/divideAndConquer.ml
+++ b/lib/divideAndConquer.ml
@@ -27,6 +27,7 @@ let stub_subproblems: ast -> ast * ast list
       let ast', subproblems1 = stub_subproblems' elements in 
       let rhss, subproblems2 = stub_subproblems_prod_rule_rhss nt elements rhss in
       ProdRule (nt, ias, rhss, p) :: ast', subproblems1 @ subproblems2
+    | InlinedTypeProdRule _ -> assert false
     | TypeAnnotation (_, _, [], _) -> 
       let ast', subproblems = stub_subproblems' elements in 
       element :: ast', subproblems

--- a/lib/eliminateTaConstraints.ml
+++ b/lib/eliminateTaConstraints.ml
@@ -3,6 +3,7 @@ module A = Ast
 let eliminate_ta_constraints full_ast = 
   let rec helper full_ast ast = match ast with 
   | [] -> full_ast 
+  | (A.InlinedTypeProdRule _) :: _ -> assert false
   | (A.ProdRule _) :: tl -> 
     helper full_ast tl   
   | A.TypeAnnotation (nt, _, scs, _) :: tl -> 
@@ -18,6 +19,7 @@ let eliminate_ta_constraints full_ast =
     | A.TypeAnnotation (nt2, ty, _, p) as element ->
       (* Maintain attribute definitions because we will detect and reject later *)
       if nt = nt2 then A.TypeAnnotation (nt2, ty, attrs, p) else element
+    | A.InlinedTypeProdRule _ -> assert false
     | A.ProdRule (nt3, ias, rhss, pos2) -> 
       let rhss = List.map (function 
         | A.StubbedRhs _ as rhs -> rhs 

--- a/lib/grammarFuzzing.ml
+++ b/lib/grammarFuzzing.ml
@@ -384,6 +384,7 @@ let sample_from_percentile_range (pop : child list) (lower_percentile: float) (u
 let rec check_well_formed_rules (grammar : ast) : bool =
   match grammar with
   | [] -> true
+  | InlinedTypeProdRule _ :: _  -> assert false
   | ProdRule(nt, _, rhsList, _) :: xs -> (not (List.length rhsList = 1 && isNonTerminalPresent nt rhsList)) && check_well_formed_rules xs
   | TypeAnnotation(_, _, _, _) :: xs -> check_well_formed_rules xs
 

--- a/lib/mergeOverlappingConstraints.ml
+++ b/lib/mergeOverlappingConstraints.ml
@@ -37,10 +37,12 @@ let merge: A.ast -> A.element -> A.ast
           else rhs
         ) rhss in 
         acc @ [A.ProdRule (nt2, ias, rhss, p)]
+      | A.InlinedTypeProdRule _ -> assert false
       ) [] ast in 
       ast @ [A.TypeAnnotation (nt, ty, [], p)]
     (* If no overlapping constraint, no action is required *)
     else ast @ [element]
+  | A.InlinedTypeProdRule _ -> assert false
   | A.ProdRule (nt, ias, rhss, p) -> 
     (* To find overlaps, look for semantic constraint pairs where 
         * One semantic constraint is in __this__ production rule and has a nonterminal of the form 
@@ -95,6 +97,7 @@ let merge: A.ast -> A.element -> A.ast
           else rhs
         ) rhss in 
         acc @ [A.ProdRule (nt2, ias, rhss, p)]
+      | A.InlinedTypeProdRule _ -> assert false
       ) [] ast in 
       let rhss = List.map (fun rhs -> match rhs with 
       | A.StubbedRhs _ -> rhs 
@@ -139,12 +142,14 @@ let lift: A.ast -> A.element -> A.ast
       ) rhss in
       ast @ [A.ProdRule (nt, ias, rhss, p)]
     else ast @ [element]
+  | A.InlinedTypeProdRule _ -> assert false
 
 let detect: A.ast -> A.element -> bool
 = fun ast element -> match element with 
   | A.TypeAnnotation (_, _, [], _) -> false 
   | A.TypeAnnotation (nt, _, _ :: _, _) -> 
     A.ast_constrains_nt ast nt 
+  | A.InlinedTypeProdRule _ -> assert false
   | A.ProdRule (nt, _, rhss, _) -> 
     let scs = List.concat_map (fun rhs -> match rhs with 
     | A.StubbedRhs _ -> []

--- a/lib/mutationOps.ml
+++ b/lib/mutationOps.ml
@@ -62,6 +62,7 @@ let rec mutation_add_s1 (g : ast) (nt : string) (pr : element option) : ast * bo
         | TypeAnnotation(x,y,z,pos) :: xs -> 
             let (gg, r) = mutation_add_s1 xs nt pr in 
                 ((TypeAnnotation(x,y,z,pos) :: gg), r)
+        | InlinedTypeProdRule _ :: _ -> assert false
             (* x :: mutation_add_s1 (xs nt pr) *)
     )
     | Some _ -> g, false
@@ -135,6 +136,7 @@ let rec apply_delete_to_rule nt production_options =
 let rec mutation_delete g nt =
     match g with
     | [] -> ([], false)
+    | InlinedTypeProdRule _ :: _ -> assert false
     | ProdRule(nonTerminal, _, production_options, pos) :: xs ->
         (* if (nonTerminal = "SAE_PACKET")
         then *)
@@ -186,6 +188,7 @@ let rec apply_update_to_rule nt production_options operation =
 let rec mutation_update g nt operation =
     match g with
     | [] -> ([], false)
+    | InlinedTypeProdRule _ :: _ -> assert false
     | ProdRule(nonTerminal, _, production_options, p) :: xs ->
         let found = isNonTerminalPresent nt production_options in
             if found then
@@ -238,6 +241,7 @@ let rec replace_geList b rhs1 rhs2 crossoverPRs =
 let rec grammarUpdateAfterCrossover (nt : string) (g : ast) (rhs1 : prod_rule_rhs) (rhs2 : prod_rule_rhs) (crossoverPRs : (prod_rule_rhs * prod_rule_rhs)) : ast = 
     match g with
     | [] -> []
+    | InlinedTypeProdRule _ :: _ -> assert false
     | ProdRule(a, ia, b, p) :: xs -> 
     if a = nt then  
         let newPR = replace_geList b rhs1 rhs2 crossoverPRs in

--- a/lib/ntExprToMatch.ml
+++ b/lib/ntExprToMatch.ml
@@ -29,6 +29,7 @@ let gen_match_info ast (nt1, idx1) (nt2, _idx2) nt_ctx =
   (* Collect the corresponding patterns from the AST *) 
   let rules = List.find_map (fun element -> match element with 
   | A.TypeAnnotation _ -> None 
+  | A.InlinedTypeProdRule _ -> assert false
   | A.ProdRule (nt3, _, rhss, _) -> 
     if nt1 = nt3 then 
       Some (List.map (fun rhs -> match rhs with
@@ -498,6 +499,7 @@ let process_sc: TC.context -> A.ast -> A.semantic_constraint -> A.semantic_const
 let convert_nt_exprs_to_matches: TC.context -> A.ast -> A.ast = 
   fun ctx ast -> 
     List.map (fun element -> match element with
+    | A.InlinedTypeProdRule _ -> assert false
     | A.ProdRule (nt, ias, rhss, p) -> 
       let rhss = List.map (fun rhs -> match rhs with 
       | A.Rhs (ges, scs, prob, p) -> A.Rhs (ges, List.map (process_sc ctx ast) scs, prob, p) 

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -102,7 +102,10 @@ open Ast
 %%
 
 s: d = list(element); EOF { d } ;
-	
+
+inlined_typed_attr:
+| attr = ID; TYPEANNOT; t = il_type; { (attr, t) }
+
 element:
 (* Type annotaion *)
 | nt = nonterminal; TYPEANNOT; t = il_type; 
@@ -125,6 +128,10 @@ element:
 | nt = nonterminal; LPAREN; params = separated_nonempty_list(COMMA, ID); RPAREN; PRODUCTION; rhss = separated_nonempty_list(OPTION, rhs); SEMICOLON;
   { 
     ProdRule (nt, params, rhss, $startpos) 
+  }
+| nt = nonterminal; LPAREN; typedparams = separated_nonempty_list(COMMA, inlined_typed_attr); RPAREN; PRODUCTION; rhss = separated_nonempty_list(OPTION, rhs); SEMICOLON;
+  { 
+    InlinedTypeProdRule (nt, typedparams, rhss, $startpos) 
   }
 
 rhs:

--- a/lib/pipeline.ml
+++ b/lib/pipeline.ml
@@ -47,6 +47,11 @@ let main_pipeline ?(engine: Flags.engine option = None) ?(grammar: Ast.ast optio
     ast
   in
 
+  (* Desugar local variables *)
+  let ast = DesugarLocalVars.desugar_local_vars ast in
+  Utils.debug_print Format.pp_print_string ppf "\nDesugaring local variables complete:\n";
+  Utils.debug_print Ast.pp_print_ast ppf ast;
+
   (* Desugar type annotation constraints *) 
   let ast = EliminateTaConstraints.eliminate_ta_constraints ast in 
   Utils.debug_print Format.pp_print_string ppf "\nType annotation constraints eliminated:\n";

--- a/lib/populateIndices.ml
+++ b/lib/populateIndices.ml
@@ -28,4 +28,5 @@ let populate_indices ast =
   | A.ProdRule (nt, ias, rhss, pos) -> 
     let rhss = disambiguate_nonterminals rhss in 
     ProdRule (nt, ias, rhss, pos)
+  | A.InlinedTypeProdRule _ -> assert false
   ) ast

--- a/lib/resolveAmbiguities.ml
+++ b/lib/resolveAmbiguities.ml
@@ -143,6 +143,7 @@ let process_sc_to_list: TC.context -> string list -> A.semantic_constraint -> A.
    case at a time, ignoring constraints that aren't applicable in that case. *)
 let resolve_ambiguities_dpll: TC.context -> A.ast -> A.ast 
 = fun ctx ast -> List.map (fun element -> match element with
+| A.InlinedTypeProdRule _ -> assert false
 | A.ProdRule (nt, ias, rhss, p) ->
   (*!! Need to assume universally unique IDs *)
   let nts = List.concat_map A.nts_of_rhs rhss in 
@@ -174,6 +175,7 @@ let resolve_ambiguities_dpll: TC.context -> A.ast -> A.ast
 
 let resolve_ambiguities: TC.context -> A.ast -> A.ast 
 = fun ctx ast -> List.map (fun element -> match element with
+| A.InlinedTypeProdRule _ -> assert false
 | A.ProdRule (nt, ias, rhss, p) ->
   let rhss = List.map (fun rhs -> match rhs with 
   | A.Rhs (ges, scs, prob, _) -> A.Rhs (ges, List.map (process_sc ctx (A.nts_of_rhs rhs)) scs, prob, p) 

--- a/lib/sygus.ml
+++ b/lib/sygus.ml
@@ -46,6 +46,7 @@ let pp_print_constructor: TC.context -> Ast.semantic_constraint Utils.StringMap.
   | _, Some ty -> 
     let type_annot = List.find_opt (fun element -> match element with 
     | A.ProdRule _ -> false 
+    | A.InlinedTypeProdRule _ -> assert false
     | TypeAnnotation (nt2, _, _, _) -> nt = nt2 
     ) ast
     in (
@@ -85,6 +86,7 @@ let pp_print_datatypes: Format.formatter -> TC.context -> Ast.semantic_constrain
   ) dep_map;
   List.iter (fun element -> match element with 
   | A.TypeAnnotation _ -> ()
+  | A.InlinedTypeProdRule _ -> assert false
   | ProdRule (nt, _, rhss, _) -> 
     Format.fprintf ppf "(declare-datatype %s (%a\n))\n"
       (String.uppercase_ascii nt)
@@ -130,6 +132,7 @@ let pp_print_compop: Format.formatter -> A.comp_operator -> unit
 
 let pp_print_nt_decs: Ast.semantic_constraint Utils.StringMap.t -> Format.formatter -> A.ast -> unit 
 = fun dep_map ppf ast -> List.iter (fun element -> match element with 
+  | A.InlinedTypeProdRule _ -> assert false
   | A.ProdRule (nt, _, _, _) ->
   Format.fprintf ppf "\t(%s %s)\n"
   (String.lowercase_ascii nt)
@@ -384,6 +387,7 @@ let pp_print_semantic_constraints_prod_rule
 let pp_print_constraints: TC.context -> Format.formatter -> A.ast -> unit 
 = fun ctx ppf ast -> match ast with 
 | [] -> Utils.crash "Input grammar must have at least one production rule or type annotation"
+| A.InlinedTypeProdRule _ :: _ -> assert false
 | A.ProdRule (nt, _, rhss, _) :: _ -> 
       if List.exists (fun rhs -> match rhs with | A.Rhs (_, _ :: _, _, _) -> true | _ -> false) rhss then
   let rhss = List.mapi (fun i rhs -> (rhs, i)) rhss in
@@ -406,6 +410,7 @@ let pp_print_rhs: string -> Format.formatter -> A.prod_rule_rhs * int -> unit
 let pp_print_rules: Ast.semantic_constraint Utils.StringMap.t -> Format.formatter -> A.ast -> unit 
 = fun dep_map ppf ast -> 
   List.iter (fun element -> match element with 
+  | A.InlinedTypeProdRule _ -> assert false
   | A.ProdRule (nt, _, rhss, _) -> 
     Format.fprintf ppf "\t(%s %s (%a))\n"
       (String.lowercase_ascii nt) 
@@ -430,6 +435,7 @@ let pp_print_rules: Ast.semantic_constraint Utils.StringMap.t -> Format.formatte
 let pp_print_grammar: Format.formatter -> Ast.semantic_constraint Utils.StringMap.t -> A.ast -> unit 
 = fun ppf dep_map ast -> 
   let top_datatype_str = match List.hd ast with 
+  | A.InlinedTypeProdRule _ -> assert false
   | A.ProdRule (nt, _, _, _) -> String.uppercase_ascii nt
   | TypeAnnotation (_, ty, _, _) -> 
     Utils.capture_output pp_print_ty ty

--- a/lib/topologicalSort.ml
+++ b/lib/topologicalSort.ml
@@ -15,6 +15,7 @@ let rec get_all_nt_from_rhs (rvalue : prod_rule_rhs list) : string list =
 
 let get_all_dependencies_from_one_element (ge : element) : (string * string) list = 
   match ge with 
+  | InlinedTypeProdRule _ -> assert false
   | ProdRule(lvalue, _, rhs, _) -> (List.map (fun x-> (lvalue, x))(get_all_nt_from_rhs rhs))  |> (List.filter (fun (x,y) ->  x <> y) )
   | TypeAnnotation(_, _, _, _) -> [] 
 
@@ -38,6 +39,7 @@ let rec get_nt_from_rhs rhs =
 let rec get_all_nt (g : ast) : string list =
   match g with
   | [] -> []
+  | InlinedTypeProdRule _ :: _ -> assert false
   | ProdRule (nt, _, rhs, _) :: xs -> nt :: (get_nt_from_rhs rhs)  @ (get_all_nt xs)
   | TypeAnnotation (_, _, _, _) :: xs -> get_all_nt xs
 
@@ -64,6 +66,7 @@ let rec get_edge_pairs (nts : (string * (string list)) list): (string * string) 
 let rec get_all_rules (nt : string) (g : ast) : prod_rule_rhs list =
   match g with
   | [] -> []
+  | InlinedTypeProdRule _ :: _ -> assert false
   | ProdRule (a, _, prod_rule_lst, _) :: xs ->
     if a = nt
       then prod_rule_lst @ (get_all_rules nt xs)
@@ -120,7 +123,8 @@ let rec collect_rules_for_nt (cnt : string) (ogrammar : ast) : ast =
     else collect_rules_for_nt cnt xs 
     | TypeAnnotation(x, y, z, pos)::xs -> 
       if x = cnt then TypeAnnotation(x, y, z, pos)  :: collect_rules_for_nt cnt xs
-      else collect_rules_for_nt cnt xs 
+    else collect_rules_for_nt cnt xs
+  | InlinedTypeProdRule _ :: _ -> assert false
 
 let rec collect_rules (non_term_list : string list ) (ogrammar : ast) (cgrammar : ast) : ast = 
   match non_term_list with 

--- a/lib/typeChecker.ml
+++ b/lib/typeChecker.ml
@@ -14,6 +14,7 @@ let type_checker_error mode error_msg p = match mode with
 let build_context: ast -> ast * context
 = fun ast -> 
   let ctx = List.fold_left (fun acc element -> match element with 
+  | InlinedTypeProdRule _ -> assert false
   | ProdRule (nt, ias, rhss, _) -> 
     let options = List.map (fun rhs -> match rhs with
       | Rhs (ges, scs, _, _) -> 
@@ -422,6 +423,7 @@ let check_types: context -> ast -> ast
   | ProdRule (nt, ias, rhss, p) -> 
     let rhss = List.map (check_prod_rhs ctx) rhss in
     ProdRule (nt, ias, rhss, p)
+  | InlinedTypeProdRule _ -> assert false
   | TypeAnnotation (nt, ty, scs, p) -> 
     let scs = List.map (fun sc -> match sc with 
     | DerivedField (nt2, expr, p) ->

--- a/test/test_cases/inh-attr-inlined-fail-1.gbl
+++ b/test/test_cases/inh-attr-inlined-fail-1.gbl
@@ -1,4 +1,4 @@
-<Repeat> ::= <v>(<Str>) <Str> <Val> <L>(<Val>) <Length> { <Length> = <L>.len; <Length> > 5; <Val> > 1; str.len(<Str>) = 2; };
+<Repeat> ::= <v>(<Str>) <Str> <Val> <L> <Length> { <Length> = <L>.len; <Length> > 5; <Val> > 1; str.len(<Str>) = 2; };
 <L>(v::Int) ::= <E> <L>(v - 1) { <E> = v; len := 1 + <L>.len; } | <Nil> { len := 0; };
 <v>(v::String) ::= <S> { <S> = v; };
 

--- a/test/test_cases/inh-attr-inlined-fail-2.gbl
+++ b/test/test_cases/inh-attr-inlined-fail-2.gbl
@@ -1,4 +1,4 @@
-<Repeat> ::= <v>(<Str>) <Str> <Val> <L>(<Val>) <Length> { <Length> = <L>.len; <Length> > 5; <Val> > 1; str.len(<Str>) = 2; };
+<Repeat> ::= <v>(<Str>) <Str> <Val> <L>(<Str>) <Length> { <Length> = <L>.len; <Length> > 5; <Val> > 1; str.len(<Str>) = 2; };
 <L>(v::Int) ::= <E> <L>(v - 1) { <E> = v; len := 1 + <L>.len; } | <Nil> { len := 0; };
 <v>(v::String) ::= <S> { <S> = v; };
 

--- a/test/test_cases/inh-attr-inlined.gbl
+++ b/test/test_cases/inh-attr-inlined.gbl
@@ -1,0 +1,16 @@
+<Repeat> ::= <M>(<Str>) <Str> <Val> <L>(<Val>) <Length> { <Length> = <L>.len; <Length> > 5; <Val> > 1; str.len(<Str>) = 2; };
+<L>(v::Int) ::= <E> <L>(v - 1) { <E> = v; len := 1 + <L>.len; } | <Nil> { len := 0; };
+<M>(v::String) ::= <S> { <S> = v; };
+
+<Val> :: Int;
+<E> :: Int;
+<Nil> :: Unit;
+<Length> :: Int;
+len :: Int;
+<Str> :: String;
+<S> :: String;
+
+// * Each lhs <Nt>(v) ::= ... desugars to extra nonterminal %_v on RHS
+// * Each call site <Nt>(<expr>) is desugared to a semantic constraint that <Nt>.<%_attribute> = <expr>
+// * Here, we need actually <Nt>[i].<_attribute> = <expr> for the corresponding i
+// * Check call args have the correct type

--- a/test/test_goblin.ml
+++ b/test/test_goblin.ml
@@ -49,6 +49,18 @@ let inh_attr_fail_2 () =
   | _ -> Alcotest.fail "Expected exception, but got success"
   | exception _ -> ()  
 
+let inh_attr_inlined_fail_1 () =
+  let input = "../../../test/test_cases/inh-attr-inlined-fail-1.gbl" in
+  match main_pipeline input with
+  | _ -> Alcotest.fail "Expected exception, but got success"
+  | exception _ -> ()  
+
+let inh_attr_inlined_fail_2 () =
+  let input = "../../../test/test_cases/inh-attr-inlined-fail-2.gbl" in
+  match main_pipeline input with
+  | _ -> Alcotest.fail "Expected exception, but got success"
+  | exception _ -> ()  
+
 let bug3 () =
   let input = "../../../test/test_cases/bug3.gbl" in
   match main_pipeline input with
@@ -462,6 +474,14 @@ let length_attr_fail_3 () =
 
 let inh_attr () =
   let input = "../../../test/test_cases/inh-attr.gbl" in
+  let solver_ast, _, ast = main_pipeline input in
+  let output = CheckSolverAst.check_solver_ast ast solver_ast in
+  match output with
+  | Ok _ -> ()  
+  | Error msg -> fail msg
+
+let inh_attr_inlined () =
+  let input = "../../../test/test_cases/inh-attr-inlined.gbl" in
   let solver_ast, _, ast = main_pipeline input in
   let output = CheckSolverAst.check_solver_ast ast solver_ast in
   match output with
@@ -1730,8 +1750,11 @@ let () =
     "length_attr_fail_2", [test_case "length_attr_fail_2" `Quick length_attr_fail_2]; 
     "length_attr_fail_3", [test_case "length_attr_fail_3" `Quick length_attr_fail_3]; 
     "inh_attr", [test_case "inh_attr" `Quick inh_attr]; 
+    "inh_attr_inlined", [test_case "inh_attr_inlined" `Quick inh_attr_inlined];
     "inh_attr_fail_1", [test_case "inh_attr_fail_1" `Quick inh_attr_fail_1]; 
     "inh_attr_fail_2", [test_case "inh_attr_fail_2" `Quick inh_attr_fail_2]; 
+    "inh_attr_inlined_fail_1", [test_case "inh_attr_inlined_fail_1" `Quick inh_attr_inlined_fail_1]; 
+    "inh_attr_inlined_fail_2", [test_case "inh_attr_inlined_fail_2" `Quick inh_attr_inlined_fail_2];
     "index", [test_case "index" `Quick index]; 
     (*"msg2", [test_case "msg2" `Quick msg2]; *)
     (*"dd_test_another_ambiguous_reference_2", [test_case "dd_test_another_ambiguous_reference_2" `Quick dd_test_another_ambiguous_reference_2]; 


### PR DESCRIPTION
Allow inherited attributes to inline type annotations inside the production rule.