### PR TITLE
Simplify evaluator

### DIFF
--- a/lib/checkSolverAst.ml
+++ b/lib/checkSolverAst.ml
@@ -59,7 +59,7 @@ let handle_scs ast solver_ast constructor element scs =
         A.pp_print_expr expr
         SA.pp_print_solver_ast solver_ast
         );
-      ComputeDeps.evaluate false solver_ast ast element expr)
+      ComputeDeps.evaluate solver_ast ast element expr)
     else (
       (if !Flags.debug then Format.fprintf Format.std_formatter "Constraint %a is not applicable in %a"
         A.pp_print_expr expr
@@ -72,7 +72,7 @@ let handle_scs ast solver_ast constructor element scs =
       A.pp_print_expr expr
       SA.pp_print_solver_ast solver_ast
       );
-    ComputeDeps.evaluate false solver_ast ast element expr
+    ComputeDeps.evaluate solver_ast ast element expr
   | AttrDef _ -> assert false
   ) scs in
   let b = List.exists (fun sc -> match sc with 

--- a/lib/computeDeps.ml
+++ b/lib/computeDeps.ml
@@ -125,7 +125,6 @@ and bool_list_to_il_int (signed : bool) (bits : bool list) p : A.expr =
   else
     A.IntConst (unsigned_val, p)
 
-(* Input boolean denotes whether we are in the context of computing a length(.) expression *)
 and evaluate: ?dep_map:A.semantic_constraint Utils.StringMap.t -> SA.solver_ast -> A.ast -> A.element -> A.expr -> A.expr list
 = fun ?(dep_map=Utils.StringMap.empty) solver_ast ast element expr -> 
   if !Flags.debug then 

--- a/lib/computeDeps.ml
+++ b/lib/computeDeps.ml
@@ -472,7 +472,7 @@ and compute_deps: A.semantic_constraint Utils.StringMap.t -> A.ast -> SA.solver_
       (*A.pp_print_ast ast *)
       SA.pp_print_solver_ast solver_ast;
   match solver_ast with
-| VarLeaf _ -> eval_fail 28
+| VarLeaf _ -> eval_fail  28
 | UnitLeaf -> Utils.crash "Unexpected case"
 | Node ((constructor, idx), subterms) -> 
   let subterms = 

--- a/lib/dpll.ml
+++ b/lib/dpll.ml
@@ -279,7 +279,6 @@ match dt with
         | A.Nonterminal (nt, idx_opt, _, _) ->
           Node ((nt, idx_opt), path @ [nt, idx_opt], [])  
         | StubbedNonterminal (_id, stub_id) -> 
-          (*DependentTermLeaf stub_id*)
           Node ((_id, None), path @ [_id, None], [DependentTermLeaf stub_id])
         ) ges in
        Some children 
@@ -535,7 +534,8 @@ let find_new_expansion ast derivation_tree curr_st_node =
         let children = List.map (fun ge -> match ge with 
         | A.Nonterminal (nt, idx_opt, _, _) ->
           Node ((nt, idx_opt), path @ [nt, idx_opt], [])  
-        | StubbedNonterminal (_, stub_id) -> DependentTermLeaf stub_id
+        | StubbedNonterminal (nt_id, stub_id) -> 
+          Node ((nt_id, None), path @ [nt_id, None], [DependentTermLeaf stub_id])
         ) ges in 
         let expanded_node = Node ((nt, idx), path, children) in 
         expanded_node, expanded_node 
@@ -712,7 +712,7 @@ let rec fill_unconstrained_nonterminals: derivation_tree -> derivation_tree
     ConcreteSetLeaf (path, (ConcreteStringSetLeaf set)) 
   | SymbolicLeaf (ADT _, _) -> Utils.crash "Unexpected case in fill_unconstrained_nonterminals"
   | DependentTermLeaf _ -> derivation_tree
-  | Node (nt, path, children) -> 
+  | Node (nt, path, children) ->  
     let children = List.map r children in
     Node (nt, path, children)
 
@@ -1004,12 +1004,13 @@ let dpll: A.il_type Utils.StringMap.t -> A.ast -> SA.solver_ast
         | A.AttrDef _ -> assert false
         ) scs;
       | A.ProdRule (_, _, rhss, _) -> 
-        (*Format.fprintf Format.std_formatter "Finding the chosen rule for %a\n" 
+        (*Format.printf "Finding the chosen rule for %a\n%!" 
           pp_print_derivation_tree expanded_node; *)
         let chosen_rule = List.find (fun rhs -> match rhs with 
         | A.StubbedRhs str1 -> (
           match children with 
-          | [DependentTermLeaf str2] -> Utils.str_eq_ci str1 str2 
+          | [Node ((_, None), _, [DependentTermLeaf str2])] ->
+            Utils.str_eq_ci str1 str2
           | _ -> false 
           )
         | A.Rhs (ges, _, _, _) -> 
@@ -1017,7 +1018,7 @@ let dpll: A.il_type Utils.StringMap.t -> A.ast -> SA.solver_ast
             List.for_all2 (fun child ge -> match child, ge with 
             | Node ((nt, idx), _, _), A.Nonterminal (nt2, idx2, _, _) -> 
               Utils.str_eq_ci nt nt2 && idx = idx2
-            | DependentTermLeaf stub_id1, A.StubbedNonterminal (_, stub_id2) -> 
+            | Node ((_, None), _, [DependentTermLeaf stub_id1]), A.StubbedNonterminal (_, stub_id2) ->
               Utils.str_eq_ci stub_id1 stub_id2
             | _ -> false 
             ) children ges 


### PR DESCRIPTION
1. Remove hacky `computing_length` setting in the evaluator. We only needed this to ignore "ghost nonterminals" prefixed by `_`, but we no longer need this because we can use attributes rather than ghost nonterminals.
2. Fix dependency computation bug where some dependencies wouldn't be computed because they were not wrapped in a constructor (e.g., `too_many_constraints.gbl` from the test suite)